### PR TITLE
Fix hibernate dll auto

### DIFF
--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -32,7 +32,7 @@ spring:
     open-in-view: false
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
         implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl


### PR DESCRIPTION
This pull request includes a configuration change in the `application.yaml` file to modify the Hibernate DDL auto setting.

Configuration changes:

* [`application/src/main/resources/application.yaml`](diffhunk://#diff-9cde8ff6c568fcfcd6ac2c35dbf79de3b15a86a6906c3b2b78b374185e556d23L35-R35): Changed Hibernate DDL auto setting from `create-drop` to `validate`.