### PR TITLE
Add cors management

### DIFF
--- a/application/src/main/resources/application-development.yaml
+++ b/application/src/main/resources/application-development.yaml
@@ -1,5 +1,6 @@
 ---
 application:
+  cors-allowed-origins: http://localhost:5173
   db:
     host: localhost
     port: 3306

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -13,5 +13,6 @@ services:
       APPLICATION_DB_NAME: bankwiz_db
       APPLICATION_DB_USER: bankwiz_user
       APPLICATION_DB_PASSWORD: Bankwiz2024
+      APPLICATION_CORS_ALLOWED_ORIGINS: http://localhost:5173
       SPRING_JPA_HIBERNATE_DDL_AUTO: validate
       PROFILES: development


### PR DESCRIPTION
This pull request includes updates to the configuration files to support CORS for development environments. The most important changes include adding CORS allowed origins to the application configuration and the Docker Compose configuration.

Configuration updates:

* [`application/src/main/resources/application-development.yaml`](diffhunk://#diff-a8a082853be43c844e8e0d4496add2e77d5d704ec6ec483f0b2a6ab36f4b0d18R3): Added `cors-allowed-origins` setting to allow `http://localhost:5173` for CORS.
* [`docker/compose.app.yaml`](diffhunk://#diff-e068083035bdbc6e6905601db98b9626fe94821a0c7763ca2ab57b889010c3aeR16): Added `APPLICATION_CORS_ALLOWED_ORIGINS` environment variable to allow `http://localhost:5173` for CORS in the Docker Compose setup.